### PR TITLE
Updated e0072 bonus to new format

### DIFF
--- a/src/librustc/hir/fold.rs
+++ b/src/librustc/hir/fold.rs
@@ -15,8 +15,8 @@ use hir::*;
 use syntax::ast::{Name, NodeId, DUMMY_NODE_ID, Attribute, Attribute_};
 use syntax::ast::{NestedMetaItem, NestedMetaItemKind, MetaItem, MetaItemKind};
 use hir;
-use syntax_pos::Span;
-use syntax::codemap::{respan, Spanned};
+use syntax_pos::{Span, BytePos};
+use syntax::codemap::{spanned, respan, Spanned};
 use syntax::ptr::P;
 use syntax::parse::token::keywords;
 use syntax::util::move_map::MoveMap;
@@ -850,7 +850,7 @@ pub fn noop_fold_crate<T: Folder>(Crate { module, attrs, config, span,
     let config = folder.fold_meta_items(config);
 
     let crate_mod = folder.fold_item(hir::Item {
-        name: keywords::Invalid.name(),
+        name: spanned(BytePos(0), BytePos(0), keywords::Invalid.name()),
         attrs: attrs,
         id: DUMMY_NODE_ID,
         vis: hir::Public,
@@ -894,7 +894,7 @@ pub fn noop_fold_item<T: Folder>(item: Item, folder: &mut T) -> Item {
 
     Item {
         id: id,
-        name: folder.fold_name(name),
+        name: spanned(BytePos(0), BytePos(0), folder.fold_name(name.node)),
         attrs: fold_attrs(attrs, folder),
         node: node,
         vis: vis,

--- a/src/librustc/hir/intravisit.rs
+++ b/src/librustc/hir/intravisit.rs
@@ -276,7 +276,7 @@ pub fn walk_trait_ref<'v, V>(visitor: &mut V, trait_ref: &'v TraitRef)
 
 pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item) {
     visitor.visit_vis(&item.vis);
-    visitor.visit_name(item.span, item.name);
+    visitor.visit_name(item.span, item.name.node);
     match item.node {
         ItemExternCrate(opt_name) => {
             visitor.visit_id(item.id);
@@ -307,7 +307,7 @@ pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item) {
             visitor.visit_expr(expr);
         }
         ItemFn(ref declaration, unsafety, constness, abi, ref generics, ref body) => {
-            visitor.visit_fn(FnKind::ItemFn(item.name,
+            visitor.visit_fn(FnKind::ItemFn(item.name.node,
                                             generics,
                                             unsafety,
                                             constness,
@@ -352,7 +352,7 @@ pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item) {
         ItemUnion(ref struct_definition, ref generics) => {
             visitor.visit_generics(generics);
             visitor.visit_id(item.id);
-            visitor.visit_variant_data(struct_definition, item.name, generics, item.id, item.span);
+            visitor.visit_variant_data(struct_definition, item.name.node, generics, item.id, item.span);
         }
         ItemTrait(_, ref generics, ref bounds, ref methods) => {
             visitor.visit_id(item.id);

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -56,7 +56,8 @@ use syntax::codemap::{respan, Spanned};
 use syntax::parse::token;
 use syntax::std_inject;
 use syntax::visit::{self, Visitor};
-use syntax_pos::Span;
+use syntax_pos::{Span, BytePos};
+use syntax::codemap::{spanned};
 
 pub struct LoweringContext<'a> {
     crate_root: Option<&'static str>,
@@ -752,7 +753,7 @@ impl<'a> LoweringContext<'a> {
 
         hir::Item {
             id: i.id,
-            name: i.ident.name,
+            name: spanned(BytePos(0), BytePos(0), i.ident.name),
             attrs: self.lower_attrs(&i.attrs),
             node: node,
             vis: self.lower_visibility(&i.vis),

--- a/src/librustc/hir/map/blocks.rs
+++ b/src/librustc/hir/map/blocks.rs
@@ -225,7 +225,7 @@ impl<'a> FnLikeNode<'a> {
                 ast::ItemFn(ref decl, unsafety, constness, abi, ref generics, ref block) =>
                     item_fn(ItemFnParts {
                         id: i.id,
-                        name: i.name,
+                        name: i.name.node,
                         decl: &decl,
                         unsafety: unsafety,
                         body: &block,

--- a/src/librustc/hir/map/def_collector.rs
+++ b/src/librustc/hir/map/def_collector.rs
@@ -305,9 +305,9 @@ impl<'ast> intravisit::Visitor<'ast> for DefCollector<'ast> {
             hir::ItemEnum(..) | hir::ItemStruct(..) | hir::ItemUnion(..) |
             hir::ItemTrait(..) | hir::ItemExternCrate(..) | hir::ItemMod(..) |
             hir::ItemForeignMod(..) | hir::ItemTy(..) =>
-                DefPathData::TypeNs(i.name.as_str()),
+                DefPathData::TypeNs(i.name.node.as_str()),
             hir::ItemStatic(..) | hir::ItemConst(..) | hir::ItemFn(..) =>
-                DefPathData::ValueNs(i.name.as_str()),
+                DefPathData::ValueNs(i.name.node.as_str()),
             hir::ItemUse(..) => DefPathData::Misc,
         };
         let def = self.create_def(i.id, def_data);

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -632,7 +632,7 @@ impl<'ast> Map<'ast> {
     /// Returns the name associated with the given NodeId's AST.
     pub fn name(&self, id: NodeId) -> Name {
         match self.get(id) {
-            NodeItem(i) => i.name,
+            NodeItem(i) => i.name.node,
             NodeForeignItem(i) => i.name,
             NodeImplItem(ii) => ii.name,
             NodeTraitItem(ti) => ti.name,
@@ -770,7 +770,7 @@ impl<'a, 'ast> NodesMatchingSuffix<'a, 'ast> {
                 match map.find(id) {
                     None => return None,
                     Some(NodeItem(item)) if item_is_mod(&item) =>
-                        return Some((id, item.name)),
+                        return Some((id, item.name.node)),
                     _ => {}
                 }
                 let parent = map.get_parent(id);
@@ -826,7 +826,7 @@ trait Named {
 
 impl<T:Named> Named for Spanned<T> { fn name(&self) -> Name { self.node.name() } }
 
-impl Named for Item { fn name(&self) -> Name { self.name } }
+impl Named for Item { fn name(&self) -> Name { self.name.node } }
 impl Named for ForeignItem { fn name(&self) -> Name { self.name } }
 impl Named for Variant_ { fn name(&self) -> Name { self.name } }
 impl Named for TraitItem { fn name(&self) -> Name { self.name } }

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -1450,7 +1450,7 @@ pub struct ItemId {
 /// The name might be a dummy name in case of anonymous items
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub struct Item {
-    pub name: Name,
+    pub name: Spanned<Name>,
     pub attrs: HirVec<Attribute>,
     pub id: NodeId,
     pub node: Item_,

--- a/src/librustc/hir/print.rs
+++ b/src/librustc/hir/print.rs
@@ -662,7 +662,7 @@ impl<'a> State<'a> {
                     word(&mut self.s, "as")?;
                     space(&mut self.s)?;
                 }
-                self.print_name(item.name)?;
+                self.print_name(item.name.node)?;
                 word(&mut self.s, ";")?;
                 self.end()?; // end inner head-block
                 self.end()?; // end outer head-block
@@ -679,7 +679,7 @@ impl<'a> State<'a> {
                 if m == hir::MutMutable {
                     self.word_space("mut")?;
                 }
-                self.print_name(item.name)?;
+                self.print_name(item.name.node)?;
                 self.word_space(":")?;
                 self.print_type(&ty)?;
                 space(&mut self.s)?;
@@ -692,7 +692,7 @@ impl<'a> State<'a> {
             }
             hir::ItemConst(ref ty, ref expr) => {
                 self.head(&visibility_qualified(&item.vis, "const"))?;
-                self.print_name(item.name)?;
+                self.print_name(item.name.node)?;
                 self.word_space(":")?;
                 self.print_type(&ty)?;
                 space(&mut self.s)?;
@@ -709,7 +709,7 @@ impl<'a> State<'a> {
                               unsafety,
                               constness,
                               abi,
-                              Some(item.name),
+                              Some(item.name.node),
                               typarams,
                               &item.vis)?;
                 word(&mut self.s, " ")?;
@@ -717,7 +717,7 @@ impl<'a> State<'a> {
             }
             hir::ItemMod(ref _mod) => {
                 self.head(&visibility_qualified(&item.vis, "mod"))?;
-                self.print_name(item.name)?;
+                self.print_name(item.name.node)?;
                 self.nbsp()?;
                 self.bopen()?;
                 self.print_mod(_mod, &item.attrs)?;
@@ -734,7 +734,7 @@ impl<'a> State<'a> {
                 self.ibox(indent_unit)?;
                 self.ibox(0)?;
                 self.word_nbsp(&visibility_qualified(&item.vis, "type"))?;
-                self.print_name(item.name)?;
+                self.print_name(item.name.node)?;
                 self.print_generics(params)?;
                 self.end()?; // end the inner ibox
 
@@ -746,15 +746,15 @@ impl<'a> State<'a> {
                 self.end()?; // end the outer ibox
             }
             hir::ItemEnum(ref enum_definition, ref params) => {
-                self.print_enum_def(enum_definition, params, item.name, item.span, &item.vis)?;
+                self.print_enum_def(enum_definition, params, item.name.node, item.span, &item.vis)?;
             }
             hir::ItemStruct(ref struct_def, ref generics) => {
                 self.head(&visibility_qualified(&item.vis, "struct"))?;
-                self.print_struct(struct_def, generics, item.name, item.span, true)?;
+                self.print_struct(struct_def, generics, item.name.node, item.span, true)?;
             }
             hir::ItemUnion(ref struct_def, ref generics) => {
                 self.head(&visibility_qualified(&item.vis, "union"))?;
-                self.print_struct(struct_def, generics, item.name, item.span, true)?;
+                self.print_struct(struct_def, generics, item.name.node, item.span, true)?;
             }
             hir::ItemDefaultImpl(unsafety, ref trait_ref) => {
                 self.head("")?;
@@ -816,7 +816,7 @@ impl<'a> State<'a> {
                 self.print_visibility(&item.vis)?;
                 self.print_unsafety(unsafety)?;
                 self.word_nbsp("trait")?;
-                self.print_name(item.name)?;
+                self.print_name(item.name.node)?;
                 self.print_generics(generics)?;
                 let mut real_bounds = Vec::with_capacity(bounds.len());
                 for b in bounds.iter() {

--- a/src/librustc/infer/error_reporting.rs
+++ b/src/librustc/infer/error_reporting.rs
@@ -992,7 +992,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                 ast_map::NodeItem(ref item) => {
                     match item.node {
                         hir::ItemFn(ref fn_decl, unsafety, constness, _, ref gen, _) => {
-                            Some((fn_decl, gen, unsafety, constness, item.name, item.span))
+                            Some((fn_decl, gen, unsafety, constness, item.name.node, item.span))
                         },
                         _ => None
                     }

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -520,7 +520,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for DeadVisitor<'a, 'tcx> {
             self.warn_dead_code(
                 item.id,
                 item.span,
-                item.name,
+                item.name.node,
                 item.node.descriptive_variant()
             );
         } else {

--- a/src/librustc/middle/entry.rs
+++ b/src/librustc/middle/entry.rs
@@ -88,7 +88,7 @@ fn entry_point_type(item: &Item, at_root: bool) -> EntryPointType {
                 EntryPointType::Start
             } else if attr::contains_name(&item.attrs, "main") {
                 EntryPointType::MainAttr
-            } else if item.name.as_str() == "main" {
+            } else if item.name.node.as_str() == "main" {
                 if at_root {
                     // This is a top-level function so can be 'main'
                     EntryPointType::MainNamed

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -458,7 +458,7 @@ impl<'a, 'v, 'tcx> Visitor<'v> for Checker<'a, 'tcx> {
         // When compiling with --test we don't enforce stability on the
         // compiler-generated test module, demarcated with `DUMMY_SP` plus the
         // name `__test`
-        if item.span == DUMMY_SP && item.name.as_str() == "__test" { return }
+        if item.span == DUMMY_SP && item.name.node.as_str() == "__test" { return }
 
         check_item(self.tcx, item, true,
                    &mut |id, sp, stab, depr| self.check(id, sp, stab, depr));

--- a/src/librustc_lint/bad_style.rs
+++ b/src/librustc_lint/bad_style.rs
@@ -112,16 +112,16 @@ impl LateLintPass for NonCamelCaseTypes {
 
         match it.node {
             hir::ItemTy(..) | hir::ItemStruct(..) | hir::ItemUnion(..) => {
-                self.check_case(cx, "type", it.name, it.span)
+                self.check_case(cx, "type", it.name.node, it.span)
             }
             hir::ItemTrait(..) => {
-                self.check_case(cx, "trait", it.name, it.span)
+                self.check_case(cx, "trait", it.name.node, it.span)
             }
             hir::ItemEnum(ref enum_definition, _) => {
                 if has_extern_repr {
                     return;
                 }
-                self.check_case(cx, "type", it.name, it.span);
+                self.check_case(cx, "type", it.name.node, it.span);
                 for variant in &enum_definition.variants {
                     self.check_case(cx, "variant", variant.node.name, variant.span);
                 }
@@ -257,7 +257,7 @@ impl LateLintPass for NonSnakeCase {
 
     fn check_item(&mut self, cx: &LateContext, it: &hir::Item) {
         if let hir::ItemMod(_) = it.node {
-            self.check_snake_case(cx, "module", &it.name.as_str(), Some(it.span));
+            self.check_snake_case(cx, "module", &it.name.node.as_str(), Some(it.span));
         }
     }
 
@@ -329,10 +329,10 @@ impl LateLintPass for NonUpperCaseGlobals {
         match it.node {
             // only check static constants
             hir::ItemStatic(_, hir::MutImmutable, _) => {
-                NonUpperCaseGlobals::check_upper_case(cx, "static constant", it.name, it.span);
+                NonUpperCaseGlobals::check_upper_case(cx, "static constant", it.name.node, it.span);
             }
             hir::ItemConst(..) => {
-                NonUpperCaseGlobals::check_upper_case(cx, "constant", it.name, it.span);
+                NonUpperCaseGlobals::check_upper_case(cx, "constant", it.name.node, it.span);
             }
             _ => {}
         }

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1041,7 +1041,7 @@ impl LateLintPass for InvalidNoMangleItems {
                 if attr::contains_name(&it.attrs, "no_mangle") {
                     if !cx.access_levels.is_reachable(it.id) {
                         let msg = format!("function {} is marked #[no_mangle], but not exported",
-                                          it.name);
+                                          it.name.node);
                         cx.span_lint(PRIVATE_NO_MANGLE_FNS, it.span, &msg);
                     }
                     if generics.is_parameterized() {
@@ -1055,7 +1055,7 @@ impl LateLintPass for InvalidNoMangleItems {
                 if attr::contains_name(&it.attrs, "no_mangle") &&
                        !cx.access_levels.is_reachable(it.id) {
                     let msg = format!("static {} is marked #[no_mangle], but not exported",
-                                      it.name);
+                                      it.name.node);
                     cx.span_lint(PRIVATE_NO_MANGLE_STATICS, it.span, &msg);
                 }
             },

--- a/src/librustc_metadata/astencode.rs
+++ b/src/librustc_metadata/astencode.rs
@@ -145,7 +145,7 @@ pub fn decode_inlined_item<'a, 'tcx>(cdata: &cstore::CrateMetadata,
                                        decode_ast(ast_doc),
                                        dcx);
     let name = match *ii {
-        InlinedItem::Item(_, ref i) => i.name,
+        InlinedItem::Item(_, ref i) => i.name.node,
         InlinedItem::TraitItem(_, ref ti) => ti.name,
         InlinedItem::ImplItem(_, ref ii) => ii.name
     };

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -477,7 +477,7 @@ impl<'a, 'tcx, 'encoder> ItemContentBuilder<'a, 'tcx, 'encoder> {
             ty::VariantKind::Unit => 'u',
         });
         self.encode_bounds_and_type_for_item(ctor_node_id);
-        encode_name(self.rbml_w, item.name);
+        encode_name(self.rbml_w, item.name.node);
         self.encode_parent_item(struct_def_id);
 
         let stab = ecx.tcx.lookup_stability(ctor_def_id);
@@ -909,7 +909,7 @@ impl<'a, 'tcx, 'encoder> ItemContentBuilder<'a, 'tcx, 'encoder> {
                     encode_family(self.rbml_w, 'c');
                 }
                 self.encode_bounds_and_type_for_item(item.id);
-                encode_name(self.rbml_w, item.name);
+                encode_name(self.rbml_w, item.name.node);
                 self.encode_visibility(vis);
                 encode_stability(self.rbml_w, stab);
                 encode_deprecation(self.rbml_w, depr);
@@ -919,7 +919,7 @@ impl<'a, 'tcx, 'encoder> ItemContentBuilder<'a, 'tcx, 'encoder> {
                 encode_def_id_and_key(ecx, self.rbml_w, def_id);
                 encode_family(self.rbml_w, 'C');
                 self.encode_bounds_and_type_for_item(item.id);
-                encode_name(self.rbml_w, item.name);
+                encode_name(self.rbml_w, item.name.node);
                 encode_attributes(self.rbml_w, &item.attrs);
                 encode_inlined_item(ecx, self.rbml_w, InlinedItemRef::Item(def_id, item));
                 self.encode_mir(item.id);
@@ -932,7 +932,7 @@ impl<'a, 'tcx, 'encoder> ItemContentBuilder<'a, 'tcx, 'encoder> {
                 encode_family(self.rbml_w, FN_FAMILY);
                 let tps_len = generics.ty_params.len();
                 self.encode_bounds_and_type_for_item(item.id);
-                encode_name(self.rbml_w, item.name);
+                encode_name(self.rbml_w, item.name.node);
                 encode_attributes(self.rbml_w, &item.attrs);
                 let needs_inline = tps_len > 0 || attr::requests_inline(&item.attrs);
                 if constness == hir::Constness::Const {
@@ -948,12 +948,12 @@ impl<'a, 'tcx, 'encoder> ItemContentBuilder<'a, 'tcx, 'encoder> {
                 self.encode_method_argument_names(&decl);
             }
             hir::ItemMod(ref m) => {
-                self.encode_info_for_mod(FromId(item.id, (m, &item.attrs, item.name, &item.vis)));
+                self.encode_info_for_mod(FromId(item.id, (m, &item.attrs, item.name.node, &item.vis)));
             }
             hir::ItemForeignMod(ref fm) => {
                 encode_def_id_and_key(ecx, self.rbml_w, def_id);
                 encode_family(self.rbml_w, 'n');
-                encode_name(self.rbml_w, item.name);
+                encode_name(self.rbml_w, item.name.node);
 
                 // Encode all the items in self module.
                 for foreign_item in &fm.items {
@@ -969,7 +969,7 @@ impl<'a, 'tcx, 'encoder> ItemContentBuilder<'a, 'tcx, 'encoder> {
                 encode_def_id_and_key(ecx, self.rbml_w, def_id);
                 encode_family(self.rbml_w, 'y');
                 self.encode_bounds_and_type_for_item(item.id);
-                encode_name(self.rbml_w, item.name);
+                encode_name(self.rbml_w, item.name.node);
                 self.encode_visibility(vis);
                 encode_stability(self.rbml_w, stab);
                 encode_deprecation(self.rbml_w, depr);
@@ -979,7 +979,7 @@ impl<'a, 'tcx, 'encoder> ItemContentBuilder<'a, 'tcx, 'encoder> {
                 encode_family(self.rbml_w, 't');
                 encode_item_variances(self.rbml_w, ecx, item.id);
                 self.encode_bounds_and_type_for_item(item.id);
-                encode_name(self.rbml_w, item.name);
+                encode_name(self.rbml_w, item.name.node);
                 encode_attributes(self.rbml_w, &item.attrs);
                 self.encode_repr_attrs(&item.attrs);
                 for v in &enum_definition.variants {
@@ -1008,7 +1008,7 @@ impl<'a, 'tcx, 'encoder> ItemContentBuilder<'a, 'tcx, 'encoder> {
                 self.encode_bounds_and_type_for_item(item.id);
 
                 encode_item_variances(self.rbml_w, ecx, item.id);
-                encode_name(self.rbml_w, item.name);
+                encode_name(self.rbml_w, item.name.node);
                 encode_attributes(self.rbml_w, &item.attrs);
                 encode_stability(self.rbml_w, stab);
                 encode_deprecation(self.rbml_w, depr);
@@ -1038,7 +1038,7 @@ impl<'a, 'tcx, 'encoder> ItemContentBuilder<'a, 'tcx, 'encoder> {
                 self.encode_bounds_and_type_for_item(item.id);
 
                 encode_item_variances(self.rbml_w, ecx, item.id);
-                encode_name(self.rbml_w, item.name);
+                encode_name(self.rbml_w, item.name.node);
                 encode_attributes(self.rbml_w, &item.attrs);
                 encode_stability(self.rbml_w, stab);
                 encode_deprecation(self.rbml_w, depr);
@@ -1059,7 +1059,7 @@ impl<'a, 'tcx, 'encoder> ItemContentBuilder<'a, 'tcx, 'encoder> {
             hir::ItemDefaultImpl(unsafety, _) => {
                 encode_def_id_and_key(ecx, self.rbml_w, def_id);
                 encode_family(self.rbml_w, 'd');
-                encode_name(self.rbml_w, item.name);
+                encode_name(self.rbml_w, item.name.node);
                 encode_unsafety(self.rbml_w, unsafety);
 
                 let trait_ref = tcx.impl_trait_ref(ecx.tcx.map.local_def_id(item.id)).unwrap();
@@ -1074,7 +1074,7 @@ impl<'a, 'tcx, 'encoder> ItemContentBuilder<'a, 'tcx, 'encoder> {
                 encode_def_id_and_key(ecx, self.rbml_w, def_id);
                 encode_family(self.rbml_w, 'i');
                 self.encode_bounds_and_type_for_item(item.id);
-                encode_name(self.rbml_w, item.name);
+                encode_name(self.rbml_w, item.name.node);
                 encode_attributes(self.rbml_w, &item.attrs);
                 encode_unsafety(self.rbml_w, unsafety);
                 encode_polarity(self.rbml_w, polarity);
@@ -1143,7 +1143,7 @@ impl<'a, 'tcx, 'encoder> ItemContentBuilder<'a, 'tcx, 'encoder> {
                 self.encode_predicates(&tcx.lookup_super_predicates(def_id),
                                        tag_item_super_predicates);
                 encode_trait_ref(self.rbml_w, ecx, trait_def.trait_ref, tag_item_trait_ref);
-                encode_name(self.rbml_w, item.name);
+                encode_name(self.rbml_w, item.name.node);
                 encode_attributes(self.rbml_w, &item.attrs);
                 self.encode_visibility(vis);
                 encode_stability(self.rbml_w, stab);

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -742,7 +742,7 @@ pub fn check_item_type<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>, it: &'tcx hir::Item) {
       }
       hir::ItemFn(..) => {} // entirely within check_item_body
       hir::ItemImpl(.., ref impl_items) => {
-          debug!("ItemImpl {} with id {}", it.name, it.id);
+          debug!("ItemImpl {} with id {}", it.name.node, it.id);
           let impl_def_id = ccx.tcx.map.local_def_id(it.id);
           match ccx.tcx.impl_trait_ref(impl_def_id) {
               Some(impl_trait_ref) => {
@@ -812,7 +812,7 @@ pub fn check_item_body<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>, it: &'tcx hir::Item) {
         check_bare_fn(ccx, &decl, &body, it.id);
       }
       hir::ItemImpl(.., ref impl_items) => {
-        debug!("ItemImpl {} with id {}", it.name, it.id);
+        debug!("ItemImpl {} with id {}", it.name.node, it.id);
 
         for impl_item in impl_items {
             match impl_item.node {
@@ -1187,9 +1187,28 @@ fn check_representable<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     // recursive type. It is only necessary to throw an error on those that
     // contain themselves. For case 2, there must be an inner type that will be
     // caught by case 1.
+    // rty.
     match rty.is_representable(tcx, sp) {
         Representability::SelfRecursive => {
+            println!("sp {:?}", sp);
             let item_def_id = tcx.map.local_def_id(item_id);
+            println!("item_id {:?}", item_id);
+            println!("0 node {:?} span {:?}", tcx.map.find(0), tcx.map.opt_span(0));
+            println!("1 node {:?} span {:?}", tcx.map.find(1), tcx.map.opt_span(1));
+            println!("2 node {:?} span {:?}", tcx.map.find(2), tcx.map.opt_span(2));
+            println!("3 node {:?} span {:?}", tcx.map.find(3), tcx.map.opt_span(3));
+            println!("4 node {:?} span {:?}", tcx.map.find(4), tcx.map.opt_span(4));
+            println!("5 node {:?} span {:?}", tcx.map.find(5), tcx.map.opt_span(5));
+            println!("6 node {:?} span {:?}", tcx.map.find(6), tcx.map.opt_span(6));
+            println!("7 node {:?} span {:?}", tcx.map.find(7), tcx.map.opt_span(7));
+            println!("8 node {:?} span {:?}", tcx.map.find(8), tcx.map.opt_span(8));
+            println!("9 node {:?} span {:?}", tcx.map.find(9), tcx.map.opt_span(9));
+            println!("10 node {:?} span {:?}", tcx.map.find(10), tcx.map.opt_span(10));
+            println!("11 node {:?} span {:?}", tcx.map.find(11), tcx.map.opt_span(11));
+            println!("12 node {:?} span {:?}", tcx.map.find(12), tcx.map.opt_span(12));
+            println!("13 node {:?} span {:?}", tcx.map.find(13), tcx.map.opt_span(13));
+            println!("14 node {:?} span {:?}", tcx.map.find(14), tcx.map.opt_span(14));
+            println!("15 node {:?} span {:?}", tcx.map.find(15), tcx.map.opt_span(15));
             tcx.recursive_type_with_infinite_size_error(item_def_id).emit();
             return false
         }
@@ -3216,6 +3235,9 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                              pprust::path_to_string(path))
                 .span_label(path.span, &format!("not a struct"))
                 .emit();
+
+            // println!("sess {}", self.tcx.sess);
+            println!("span {:?}", path.span);
             None
         }
     }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3219,9 +3219,6 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                              pprust::path_to_string(path))
                 .span_label(path.span, &format!("not a struct"))
                 .emit();
-
-            // println!("sess {}", self.tcx.sess);
-            println!("span {:?}", path.span);
             None
         }
     }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1190,25 +1190,7 @@ fn check_representable<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     // rty.
     match rty.is_representable(tcx, sp) {
         Representability::SelfRecursive => {
-            println!("sp {:?}", sp);
             let item_def_id = tcx.map.local_def_id(item_id);
-            println!("item_id {:?}", item_id);
-            println!("0 node {:?} span {:?}", tcx.map.find(0), tcx.map.opt_span(0));
-            println!("1 node {:?} span {:?}", tcx.map.find(1), tcx.map.opt_span(1));
-            println!("2 node {:?} span {:?}", tcx.map.find(2), tcx.map.opt_span(2));
-            println!("3 node {:?} span {:?}", tcx.map.find(3), tcx.map.opt_span(3));
-            println!("4 node {:?} span {:?}", tcx.map.find(4), tcx.map.opt_span(4));
-            println!("5 node {:?} span {:?}", tcx.map.find(5), tcx.map.opt_span(5));
-            println!("6 node {:?} span {:?}", tcx.map.find(6), tcx.map.opt_span(6));
-            println!("7 node {:?} span {:?}", tcx.map.find(7), tcx.map.opt_span(7));
-            println!("8 node {:?} span {:?}", tcx.map.find(8), tcx.map.opt_span(8));
-            println!("9 node {:?} span {:?}", tcx.map.find(9), tcx.map.opt_span(9));
-            println!("10 node {:?} span {:?}", tcx.map.find(10), tcx.map.opt_span(10));
-            println!("11 node {:?} span {:?}", tcx.map.find(11), tcx.map.opt_span(11));
-            println!("12 node {:?} span {:?}", tcx.map.find(12), tcx.map.opt_span(12));
-            println!("13 node {:?} span {:?}", tcx.map.find(13), tcx.map.opt_span(13));
-            println!("14 node {:?} span {:?}", tcx.map.find(14), tcx.map.opt_span(14));
-            println!("15 node {:?} span {:?}", tcx.map.find(15), tcx.map.opt_span(15));
             tcx.recursive_type_with_infinite_size_error(item_def_id).emit();
             return false
         }

--- a/src/librustc_typeck/coherence/mod.rs
+++ b/src/librustc_typeck/coherence/mod.rs
@@ -144,7 +144,7 @@ impl<'a, 'gcx, 'tcx> CoherenceChecker<'a, 'gcx, 'tcx> {
         if let Some(trait_ref) = self.crate_context.tcx.impl_trait_ref(impl_did) {
             debug!("(checking implementation) adding impl for trait '{:?}', item '{}'",
                    trait_ref,
-                   item.name);
+                   item.name.node);
 
             // Skip impls where one of the self type is an error type.
             // This occurs with e.g. resolve failures (#30589).

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -708,7 +708,7 @@ fn ensure_no_ty_param_bounds(ccx: &CrateCtxt,
 
 fn convert_item(ccx: &CrateCtxt, it: &hir::Item) {
     let tcx = ccx.tcx;
-    debug!("convert: item {} with id {}", it.name, it.id);
+    debug!("convert: item {} with id {}", it.name.node, it.id);
     match it.node {
         // These don't define types.
         hir::ItemExternCrate(_) | hir::ItemUse(_) | hir::ItemMod(_) => {
@@ -1060,7 +1060,7 @@ fn convert_struct_def<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
     let did = ccx.tcx.map.local_def_id(it.id);
     // Use separate constructor id for unit/tuple structs and reuse did for braced structs.
     let ctor_id = if !def.is_struct() { Some(ccx.tcx.map.local_def_id(def.id())) } else { None };
-    let variants = vec![convert_struct_variant(ccx, ctor_id.unwrap_or(did), it.name,
+    let variants = vec![convert_struct_variant(ccx, ctor_id.unwrap_or(did), it.name.node,
                                                ConstInt::Infer(0), def)];
     let adt = ccx.tcx.intern_adt_def(did, ty::AdtKind::Struct, variants);
     if let Some(ctor_id) = ctor_id {
@@ -1076,7 +1076,7 @@ fn convert_union_def<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                                 -> ty::AdtDefMaster<'tcx>
 {
     let did = ccx.tcx.map.local_def_id(it.id);
-    let variants = vec![convert_struct_variant(ccx, did, it.name, ConstInt::Infer(0), def)];
+    let variants = vec![convert_struct_variant(ccx, did, it.name.node, ConstInt::Infer(0), def)];
     ccx.tcx.intern_adt_def(did, ty::AdtKind::Union, variants)
 }
 

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -333,7 +333,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
     pub fn visit_item(&mut self, item: &hir::Item,
                       renamed: Option<ast::Name>, om: &mut Module) {
         debug!("Visiting item {:?}", item);
-        let name = renamed.unwrap_or(item.name);
+        let name = renamed.unwrap_or(item.name.node);
         match item.node {
             hir::ItemExternCrate(ref p) => {
                 let cstore = &self.cx.sess().cstore;


### PR DESCRIPTION
Will do this in several steps

- [ ] Refactor the code to use `name: Spanned<Name>`
- [ ] Calculate name.span 
- [ ] Display name.span correctly in error message